### PR TITLE
feat: self-improving-agent (low-noise edition)

### DIFF
--- a/skills/self-improving-agent/.learnings/ERRORS.md
+++ b/skills/self-improving-agent/.learnings/ERRORS.md
@@ -1,0 +1,17 @@
+# Error Log
+
+Cached error records from task execution. For troubleshooting reference only.
+
+---
+
+<!-- Template:
+
+## [YYYY-MM-DD] brief description
+
+- **Command/Tool**: What failed
+- **Error**: The error message or symptom
+- **Root Cause**: What actually went wrong
+- **Resolution**: How it was fixed
+- **Recurrence**: first | repeated
+
+-->

--- a/skills/self-improving-agent/.learnings/FEATURE_REQUESTS.md
+++ b/skills/self-improving-agent/.learnings/FEATURE_REQUESTS.md
@@ -1,0 +1,15 @@
+# Feature Requests
+
+Capability gaps and user-requested features. Logged for review, not auto-actioned.
+
+---
+
+<!-- Template:
+
+## [YYYY-MM-DD] brief description
+
+- **Gap**: What capability is missing
+- **User Need**: Why it matters
+- **Priority**: low | medium | high
+
+-->

--- a/skills/self-improving-agent/.learnings/LEARNINGS.md
+++ b/skills/self-improving-agent/.learnings/LEARNINGS.md
@@ -1,0 +1,19 @@
+# Learnings Log
+
+Cached observations from task execution. Not authoritative — review before promoting.
+
+Types: `correction` | `knowledge_gap` | `best_practice`
+
+---
+
+<!-- Template:
+
+## [YYYY-MM-DD] Category: brief title
+
+- **Type**: correction | knowledge_gap | best_practice
+- **Context**: What was happening
+- **Learning**: What was learned
+- **Confidence**: low | medium | high
+- **Promote?**: no
+
+-->

--- a/skills/self-improving-agent/SKILL.md
+++ b/skills/self-improving-agent/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: self-improving-agent
+description: >
+  Low-noise self-improvement skill. Captures learnings, errors, and corrections
+  into a local `.learnings/` cache layer. Never auto-promotes to long-term memory
+  files (SOUL.md, MEMORY.md, AGENTS.md, TOOLS.md). Promotion requires explicit
+  user approval after repeated validation.
+triggers:
+  - When a task completes and produced a durable insight worth recording
+  - When an error occurs that should be logged for future reference
+  - When user explicitly corrects agent behavior or provides reusable guidance
+  - When a capability gap is identified
+---
+
+# Self-Improving Agent (Low-Noise Edition)
+
+A conservative self-improvement system that treats `.learnings/` as a write-first
+cache layer. Nothing reaches the main system files without human review.
+
+## Quick Reference
+
+| Action | Target | Auto? |
+|--------|--------|-------|
+| Log a learning | `.learnings/LEARNINGS.md` | Yes |
+| Log an error | `.learnings/ERRORS.md` | Yes |
+| Log a feature gap | `.learnings/FEATURE_REQUESTS.md` | Yes |
+| Promote to MEMORY.md | Requires user approval | No |
+| Promote to SOUL.md | Requires user approval + review | No |
+| Promote to AGENTS.md | Requires user approval | No |
+| Promote to TOOLS.md | Requires user approval | No |
+
+## Core Principles
+
+1. **Write to cache first.** All observations go to `.learnings/`. No exceptions.
+2. **Never auto-promote.** The cache is not the system. Promotion is a deliberate act.
+3. **SOUL.md is sacred.** Modifications require explicit human review every time.
+4. **MEMORY.md is for stable truths.** Only long-term preferences, decisions, and goals belong there.
+5. **Errors and learnings stay separate.** Different logs, different purposes.
+6. **Silence is better than noise.** If unsure whether something is worth logging, don't log it.
+7. **No cross-session broadcasting of raw learnings.** Only promote distilled, verified content.
+
+## Logging Format
+
+### Learning Entry
+
+```markdown
+## [YYYY-MM-DD] Category: brief title
+
+- **Type**: correction | knowledge_gap | best_practice
+- **Context**: What was happening
+- **Learning**: What was learned
+- **Confidence**: low | medium | high
+- **Promote?**: no (default) | candidate | promoted
+```
+
+### Error Entry
+
+```markdown
+## [YYYY-MM-DD] brief description
+
+- **Command/Tool**: What failed
+- **Error**: The error message or symptom
+- **Root Cause**: What actually went wrong
+- **Resolution**: How it was fixed
+- **Recurrence**: first | repeated
+```
+
+### Feature Request Entry
+
+```markdown
+## [YYYY-MM-DD] brief description
+
+- **Gap**: What capability is missing
+- **User Need**: Why it matters
+- **Priority**: low | medium | high
+```
+
+## Promotion Gates
+
+A cached item may be promoted to a system file **only** when ALL of these are true:
+
+1. **Repeated** — The same insight has appeared in 2+ separate sessions
+2. **Verified** — The insight was confirmed correct (not a one-off misunderstanding)
+3. **User-approved** — The user explicitly agrees to promote it
+4. **Relevant long-term** — It's not a temporary workaround or context-specific hack
+
+### Promotion Targets
+
+| Content Type | Target File | Extra Requirement |
+|---|---|---|
+| User preference / long-term decision | MEMORY.md | Stable across sessions |
+| Identity / behavior guideline | SOUL.md | **Human review mandatory** |
+| Agent capability / role definition | AGENTS.md | Verified in practice |
+| Tool usage pattern / integration | TOOLS.md | Tested and confirmed |
+
+### Promotion Process
+
+1. Agent proposes promotion with rationale
+2. User reviews the exact content to be written
+3. User explicitly approves
+4. Agent writes to target file
+5. Agent marks the cached entry as `Promote?: promoted`
+
+## Best Practices (Low-Noise)
+
+- Don't log obvious things. "Python needs indentation" is not a learning.
+- Don't log things already in the codebase or docs.
+- One entry per insight. No walls of text.
+- Prefer updating an existing entry over creating a duplicate.
+- Review `.learnings/` periodically. Prune stale entries.
+- When in doubt, skip the log. You can always add it later.
+
+## OpenClaw Integration
+
+See `references/openclaw-integration.md` for how this skill fits into the
+OpenClaw workspace architecture.
+
+### Key Boundaries
+
+```
+┌─────────────────────────────────────┐
+│  Main System Layer (protected)      │
+│  SOUL.md · MEMORY.md · AGENTS.md   │
+│  TOOLS.md                           │
+│  ← promotion requires approval →    │
+├─────────────────────────────────────┤
+│  Cache Layer (free-write)           │
+│  .learnings/LEARNINGS.md            │
+│  .learnings/ERRORS.md               │
+│  .learnings/FEATURE_REQUESTS.md     │
+└─────────────────────────────────────┘
+```

--- a/skills/self-improving-agent/references/openclaw-integration.md
+++ b/skills/self-improving-agent/references/openclaw-integration.md
@@ -1,0 +1,76 @@
+# OpenClaw Integration Guide
+
+How `self-improving-agent` fits into the OpenClaw workspace architecture.
+
+## Architecture: Two-Layer Model
+
+```
+┌──────────────────────────────────────────┐
+│  Main System Layer (OpenClaw managed)    │
+│                                          │
+│  SOUL.md      — identity & principles    │
+│  MEMORY.md    — long-term stable memory  │
+│  AGENTS.md    — agent roles & caps       │
+│  TOOLS.md     — tool configs & patterns  │
+│                                          │
+│  Write access: manual curation only      │
+└──────────────┬───────────────────────────┘
+               │ promotion (manual, gated)
+┌──────────────┴───────────────────────────┐
+│  Cache Layer (self-improving-agent)      │
+│                                          │
+│  .learnings/LEARNINGS.md                 │
+│  .learnings/ERRORS.md                    │
+│  .learnings/FEATURE_REQUESTS.md          │
+│                                          │
+│  Write access: free (default target)     │
+└──────────────────────────────────────────┘
+```
+
+## Rules
+
+### 1. `.learnings/` is the cache layer
+
+- All runtime observations, corrections, and errors land here first.
+- This is disposable. Entries can be pruned or discarded without consequence.
+- No other agent or session should treat `.learnings/` as authoritative.
+
+### 2. Main system files are the source of truth
+
+- `SOUL.md` defines identity and behavioral guidelines. Changes require human review.
+- `MEMORY.md` stores stable, long-term user preferences and decisions. Not a scratchpad.
+- `AGENTS.md` defines agent capabilities and roles. Updated when capabilities change.
+- `TOOLS.md` defines tool configurations and usage patterns. Updated when tools change.
+
+### 3. Promotion is manual curation
+
+Promotion from cache → main system requires:
+
+1. The insight has appeared in **2+ sessions** (not a one-off)
+2. The insight is **verified correct** (not a misunderstanding)
+3. The user **explicitly approves** the promotion
+4. The content is **distilled** — not raw logs, but clean, concise entries
+
+### 4. Cross-session boundaries
+
+- Raw `.learnings/` content must NOT be broadcast to other sessions or agents.
+- Only promoted (distilled) content in main system files is shared.
+- If an insight hasn't been promoted, it stays local to the session that captured it.
+
+### 5. SOUL.md special handling
+
+SOUL.md is the most sensitive file. Additional rules:
+
+- Never write to SOUL.md without showing the exact diff to the user first.
+- Never add temporary or context-specific content to SOUL.md.
+- SOUL.md changes should be rare. If you're changing it frequently, something is wrong.
+
+## Anti-Patterns
+
+| Don't do this | Do this instead |
+|---|---|
+| Auto-append to MEMORY.md after every task | Write to `.learnings/LEARNINGS.md` |
+| Add error logs to SOUL.md | Write to `.learnings/ERRORS.md` |
+| Broadcast raw learnings across sessions | Promote distilled content to main files |
+| Promote after a single occurrence | Wait for 2+ occurrences, then propose |
+| Modify SOUL.md without user review | Always show diff, always get approval |

--- a/skills/self-improving-agent/scripts/activator.sh
+++ b/skills/self-improving-agent/scripts/activator.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# self-improving-agent activator
+# Read-only reminder script. Does not modify any files.
+
+set -euo pipefail
+
+LEARNINGS_DIR="$(dirname "$0")/../.learnings"
+
+cat <<'MSG'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  self-improving-agent · post-task check
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Task completed. Before moving on, consider:
+
+  1. Was there a durable learning worth recording?
+     → Log to .learnings/LEARNINGS.md
+
+  2. Did any error occur that might recur?
+     → Log to .learnings/ERRORS.md
+
+  3. Was a capability gap exposed?
+     → Log to .learnings/FEATURE_REQUESTS.md
+
+⚠ IMPORTANT:
+  - Default target is .learnings/ (cache layer)
+  - Do NOT auto-promote to SOUL.md / MEMORY.md / AGENTS.md / TOOLS.md
+  - Promotion requires: repeated + verified + user-approved
+
+If nothing worth logging → skip. Silence > noise.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+MSG
+
+# Show current cache stats (read-only)
+if [ -d "$LEARNINGS_DIR" ]; then
+  echo ""
+  echo "Cache stats:"
+  for f in LEARNINGS.md ERRORS.md FEATURE_REQUESTS.md; do
+    if [ -f "$LEARNINGS_DIR/$f" ]; then
+      count=$(grep -c '^## \[' "$LEARNINGS_DIR/$f" 2>/dev/null || echo "0")
+      printf "  %-24s %s entries\n" "$f" "$count"
+    fi
+  done
+  echo ""
+fi

--- a/skills/self-improving-agent/scripts/error-detector.sh
+++ b/skills/self-improving-agent/scripts/error-detector.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# self-improving-agent error detector
+# Read-only script. Scans input for common error patterns and outputs reminders.
+# Does not write to any file.
+
+set -euo pipefail
+
+# Error keywords to detect
+ERROR_PATTERNS=(
+  "error:"
+  "Error:"
+  "ERROR"
+  "FAILED"
+  "failed"
+  "fatal:"
+  "Fatal:"
+  "FATAL"
+  "command not found"
+  "No such file or directory"
+  "Permission denied"
+  "Connection refused"
+  "timeout"
+  "Traceback"
+  "panic:"
+  "segfault"
+  "ENOENT"
+  "EACCES"
+  "ECONNREFUSED"
+  "exit code 1"
+  "exit status 1"
+  "ModuleNotFoundError"
+  "ImportError"
+  "SyntaxError"
+  "TypeError"
+  "ValueError"
+)
+
+INPUT="${1:-}"
+
+if [ -z "$INPUT" ]; then
+  echo "Usage: error-detector.sh <text-or-file>"
+  echo "Scans for common error patterns and suggests logging."
+  exit 0
+fi
+
+# If input is a file, read it; otherwise treat as string
+if [ -f "$INPUT" ]; then
+  CONTENT=$(cat "$INPUT")
+else
+  CONTENT="$INPUT"
+fi
+
+FOUND=0
+for pattern in "${ERROR_PATTERNS[@]}"; do
+  if echo "$CONTENT" | grep -q "$pattern" 2>/dev/null; then
+    if [ "$FOUND" -eq 0 ]; then
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo "  ⚠ Error pattern(s) detected"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo ""
+    fi
+    echo "  Found: \"$pattern\""
+    FOUND=$((FOUND + 1))
+  fi
+done
+
+if [ "$FOUND" -gt 0 ]; then
+  cat <<'MSG'
+
+Suggested action:
+  → Record to .learnings/ERRORS.md with:
+    - Command/tool that failed
+    - Error message
+    - Root cause (if known)
+    - Resolution (if found)
+
+⚠ Do NOT auto-promote to SOUL.md / MEMORY.md / AGENTS.md / TOOLS.md
+  Errors stay in the cache layer unless manually promoted.
+MSG
+else
+  echo "No error patterns detected."
+fi


### PR DESCRIPTION
## Summary

- Add `self-improving-agent` skill — a conservative self-improvement system
- Uses `.learnings/` as a write-first cache layer (LEARNINGS / ERRORS / FEATURE_REQUESTS)
- Never auto-promotes to main system files (SOUL.md, MEMORY.md, AGENTS.md, TOOLS.md)
- Promotion requires: repeated occurrence + verified correct + user approval

## Files

- `SKILL.md` — skill definition with triggers, logging format, promotion gates
- `scripts/activator.sh` — read-only post-task reminder
- `scripts/error-detector.sh` — read-only error pattern scanner
- `references/openclaw-integration.md` — two-layer architecture guide
- `.learnings/` — log templates (LEARNINGS.md, ERRORS.md, FEATURE_REQUESTS.md)

## Core Principle

> Cache first, promote never (unless explicitly approved).